### PR TITLE
Switch from file to path for octoprint 1.4

### DIFF
--- a/layerdisplay/PrintJob.py
+++ b/layerdisplay/PrintJob.py
@@ -16,11 +16,11 @@ class PrintJob:
 	def __init__(self, file_selected_payload):
 		self.file_name = file_selected_payload['name']
 		self.local = file_selected_payload['origin'] == 'local'
-		self.file_path = file_selected_payload['file']
+		self.file_path = file_selected_payload['path']
 
 		if self.local:
 			self.file_size = os.path.getsize(self.file_path)
-			self._start_analysis(file_selected_payload['file'])
+			self._start_analysis(file_selected_payload['path'])
 		self.current_layer = 0
 
 	


### PR DESCRIPTION
This _should_ fix #8 and #9 

Didn't see `file` referenced elsewhere so I think this should be it.