### PR TITLE
fix payload['file'] deprecation

### DIFF
--- a/layerdisplay/PrintJob.py
+++ b/layerdisplay/PrintJob.py
@@ -12,20 +12,18 @@ class PrintJob:
 	printing = False
 	file_size = -1
 
-	
-	def __init__(self, file_selected_payload):
-		self.file_name = file_selected_payload['name']
-		self.local = file_selected_payload['origin'] == 'local'
-		self.file_path = self._file_manager.path_on_disk(
-			file_selected_payload.get("origin"), file_selected_payload.get("path")
-		)
+
+	def __init__(self, file_path, is_local):
+		self.file_path = file_path
+		self.file_name = os.path.basename(self.file_path)
+		self.local = is_local
 
 		if self.local:
 			self.file_size = os.path.getsize(self.file_path)
 			self._start_analysis(self.file_path)
 		self.current_layer = 0
 
-	
+
 	def started(self):
 		self.current_layer = 0
 		self.printing = True

--- a/layerdisplay/PrintJob.py
+++ b/layerdisplay/PrintJob.py
@@ -16,11 +16,11 @@ class PrintJob:
 	def __init__(self, file_selected_payload):
 		self.file_name = file_selected_payload['name']
 		self.local = file_selected_payload['origin'] == 'local'
-		self.file_path = file_selected_payload['file']
+		self.file_path = self._file_manager.path_on_disk(file_selected_payload.get("origin"), file_selected_payload.get("path"))
 
 		if self.local:
 			self.file_size = os.path.getsize(self.file_path)
-			self._start_analysis(file_selected_payload['file'])
+			self._start_analysis(self.file_path)
 		self.current_layer = 0
 
 	

--- a/layerdisplay/PrintJob.py
+++ b/layerdisplay/PrintJob.py
@@ -16,7 +16,9 @@ class PrintJob:
 	def __init__(self, file_selected_payload):
 		self.file_name = file_selected_payload['name']
 		self.local = file_selected_payload['origin'] == 'local'
-		self.file_path = self._file_manager.path_on_disk(file_selected_payload.get("origin"), file_selected_payload.get("path"))
+        self.file_path = self._file_manager.path_on_disk(
+            file_selected_payload.get("origin"), file_selected_payload.get("path")
+        )
 
 		if self.local:
 			self.file_size = os.path.getsize(self.file_path)

--- a/layerdisplay/PrintJob.py
+++ b/layerdisplay/PrintJob.py
@@ -16,9 +16,9 @@ class PrintJob:
 	def __init__(self, file_selected_payload):
 		self.file_name = file_selected_payload['name']
 		self.local = file_selected_payload['origin'] == 'local'
-        self.file_path = self._file_manager.path_on_disk(
-            file_selected_payload.get("origin"), file_selected_payload.get("path")
-        )
+		self.file_path = self._file_manager.path_on_disk(
+			file_selected_payload.get("origin"), file_selected_payload.get("path")
+		)
 
 		if self.local:
 			self.file_size = os.path.getsize(self.file_path)

--- a/layerdisplay/__init__.py
+++ b/layerdisplay/__init__.py
@@ -18,7 +18,7 @@ class LayerDisplayPlugin(octoprint.plugin.EventHandlerPlugin,
 
 	def on_event(self, event, payload):
 		if event == Events.FILE_SELECTED:
-			is_local = file_selected_payload.get('origin') == 'local'
+			is_local = payload.get('origin') == 'local'
 			file_path = self._file_manager.path_on_disk(payload.get("origin"), payload.get("path"))
 			self.print_job = PrintJob(file_path, is_local)
 			if self.print_job.is_analysing_gcode():

--- a/layerdisplay/__init__.py
+++ b/layerdisplay/__init__.py
@@ -18,7 +18,9 @@ class LayerDisplayPlugin(octoprint.plugin.EventHandlerPlugin,
 
 	def on_event(self, event, payload):
 		if event == Events.FILE_SELECTED:
-			self.print_job = PrintJob(payload)
+			is_local = file_selected_payload.get('origin') == 'local'
+			file_path = self._file_manager.path_on_disk(payload.get("origin"), payload.get("path"))
+			self.print_job = PrintJob(file_path, is_local)
 			if self.print_job.is_analysing_gcode():
 				self.send_analysis_progress_updates()
 				self.print_job.on_analysis_complete.register_callback(self.push_layer_info)

--- a/layerdisplay/__init__.py
+++ b/layerdisplay/__init__.py
@@ -19,7 +19,9 @@ class LayerDisplayPlugin(octoprint.plugin.EventHandlerPlugin,
 	def on_event(self, event, payload):
 		if event == Events.FILE_SELECTED:
 			is_local = payload.get('origin') == 'local'
-			file_path = self._file_manager.path_on_disk(payload.get("origin"), payload.get("path"))
+            file_path = self._file_manager.path_on_disk(
+                payload.get("origin"), payload.get("path")
+            )
 			self.print_job = PrintJob(file_path, is_local)
 			if self.print_job.is_analysing_gcode():
 				self.send_analysis_progress_updates()

--- a/layerdisplay/__init__.py
+++ b/layerdisplay/__init__.py
@@ -19,9 +19,9 @@ class LayerDisplayPlugin(octoprint.plugin.EventHandlerPlugin,
 	def on_event(self, event, payload):
 		if event == Events.FILE_SELECTED:
 			is_local = payload.get('origin') == 'local'
-            file_path = self._file_manager.path_on_disk(
-                payload.get("origin"), payload.get("path")
-            )
+			file_path = self._file_manager.path_on_disk(
+				payload.get("origin"), payload.get("path")
+			)
 			self.print_job = PrintJob(file_path, is_local)
 			if self.print_job.is_analysing_gcode():
 				self.send_analysis_progress_updates()


### PR DESCRIPTION
See #8 and #9.

It was necessary to pass the full file path because PrintJob doesn't have access to _file_manager (provided by the plugin mixins).

Works for me on my test setup and my real printer.

You can try it by installing it from `https://github.com/aerickson/layerdisplay/archive/master.zip` (go to Settings, Plugin Manager, 'Get More...', then enter the URL above in 'from URL').