### PR TITLE
make python 3 compatible

### DIFF
--- a/layerdisplay/GCodeAnalyzer.py
+++ b/layerdisplay/GCodeAnalyzer.py
@@ -1,6 +1,6 @@
-from StepperTracker import StepperTracker, PositioningMode
-from PrintJobLayerInformation import PrintJobLayerInformation
-import GCodeLineParser
+from .StepperTracker import StepperTracker, PositioningMode
+from .PrintJobLayerInformation import PrintJobLayerInformation
+from . import GCodeLineParser
 
 EXTRUSIONS_REQUIRED_FOR_FIRST_LAYER = 3
 

--- a/layerdisplay/GCodeAnalyzerTest.py
+++ b/layerdisplay/GCodeAnalyzerTest.py
@@ -1,4 +1,4 @@
-from GCodeAnalyzer import GCodeAnalyzer
+from .GCodeAnalyzer import GCodeAnalyzer
 import time
 import os
 import threading

--- a/layerdisplay/PrintJob.py
+++ b/layerdisplay/PrintJob.py
@@ -1,6 +1,6 @@
 import os
-from GCodeAnalyzer import GCodeAnalyzer
-from Event import Event
+from .GCodeAnalyzer import GCodeAnalyzer
+from .Event import Event
 from threading import Thread, Timer
 import threading
 

--- a/layerdisplay/__init__.py
+++ b/layerdisplay/__init__.py
@@ -70,6 +70,8 @@ class LayerDisplayPlugin(octoprint.plugin.EventHandlerPlugin,
 		result = LayerInfoPusher.get_layer_info_string(self.print_job)
 		return flask.jsonify(layerString = result)
 
+__python_compat__ = ">=2.7,<4"
+
 def __plugin_load__():
 	global __plugin_implementation__
 	__plugin_implementation__ = LayerDisplayPlugin()

--- a/layerdisplay/__init__.py
+++ b/layerdisplay/__init__.py
@@ -71,6 +71,7 @@ class LayerDisplayPlugin(octoprint.plugin.EventHandlerPlugin,
 		return flask.jsonify(layerString = result)
 
 __python_compat__ = ">=2.7,<4"
+__plugin_pythoncompat__ = ">=2.7,<4"
 
 def __plugin_load__():
 	global __plugin_implementation__

--- a/layerdisplay/__init__.py
+++ b/layerdisplay/__init__.py
@@ -70,7 +70,7 @@ class LayerDisplayPlugin(octoprint.plugin.EventHandlerPlugin,
 		result = LayerInfoPusher.get_layer_info_string(self.print_job)
 		return flask.jsonify(layerString = result)
 
-__python_compat__ = ">=2.7,<4"
+__plugin_name__ = "LayerDisplay"
 __plugin_pythoncompat__ = ">=2.7,<4"
 
 def __plugin_load__():

--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ plugin_package = "layerdisplay"
 plugin_name = "LayerDisplay"
 
 # The plugin's version. Can be overwritten within OctoPrint's internal data via __plugin_version__ in the plugin module
-plugin_version = "0.4.3"
+plugin_version = "0.4.3.1"
 
 # The plugin's description. Can be overwritten within OctoPrint's internal data via __plugin_description__ in the plugin
 # module


### PR DESCRIPTION
Things done:
- set __python_compat__ string
- set a __plugin_name__ string
- fix imports (see https://docs.octoprint.org/en/master/plugins/python3_migration.html#absolute-imports)
- increment version

I think this solves https://github.com/chatrat12/layerdisplay/issues/12. I couldn't find anything in the code that's truly incompatible with Python 3.

`python3 -m py_compile layerdisplay/**/*.py` looks good. 2to3's suggestions aren't required.

I think we also need to update the listing in the plugins repo (like in https://github.com/OctoPrint/plugins.octoprint.org/pull/472).

The plugin loads for me on my OctoPi installation that I've converted to use Python 3, but it's stuck at "Analysing: %0.0".

You can try it by installing via URL (https://github.com/aerickson/layerdisplay/archive/py3_compat.zip) in the OctoPrint Plugin Manager.