### PR TITLE
🐛 data['progress']['completion'] can be None

### DIFF
--- a/layerdisplay/__init__.py
+++ b/layerdisplay/__init__.py
@@ -46,7 +46,7 @@ class LayerDisplayPlugin(octoprint.plugin.EventHandlerPlugin,
 			self.push_layer_info()
 
 	def on_printer_send_current_data(self, data):
-		if data['state']['flags']['printing'] and self.print_job != None:
+		if data['state']['flags']['printing'] and self.print_job != None and data['progress'] and data['progress']['completion']:
 			progress = data['progress']['completion'] / 100
 			self.print_job.set_progress(progress)
 


### PR DESCRIPTION
276k error events due to this in the past 9 months according to OctoPrint's error tracking:

https://sentry.io/share/issue/1a3bcf483d7b426ebe1ec6b860e09444/